### PR TITLE
Bump version (v0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [v0.10.0](https://github.com/NubeIO/rubix-assist/tree/v0.10.0) (2023-02-15)
+
+- Add snapshots APIs for edge devices
+
 ## [v0.9.3](https://github.com/NubeIO/rubix-assist/tree/v0.9.3) (2023-02-05)
 
 - Improvements on CLIs


### PR DESCRIPTION
### Summary

- Add snapshots APIs for edge devices