### PR TITLE
Add patch api endpoint and description field for snapshot create and restore logs

### DIFF
--- a/amodel/snapshotcreatelog.go
+++ b/amodel/snapshotcreatelog.go
@@ -11,9 +11,10 @@ const (
 )
 
 type SnapshotCreateLog struct {
-	UUID      string       `json:"uuid" gorm:"primary_key" get:"true" delete:"true"`
-	HostUUID  string       `json:"host_uuid" get:"true" post:"true"`
-	Msg       string       `json:"msg" get:"true" post:"true" patch:"true"`
-	Status    CreateStatus `json:"status" get:"true" post:"true" patch:"true"`
-	CreatedAt time.Time    `json:"created_at" get:"true"`
+	UUID        string       `json:"uuid" gorm:"primary_key" get:"true" delete:"true"`
+	HostUUID    string       `json:"host_uuid" get:"true" post:"true"`
+	Msg         string       `json:"msg" get:"true" post:"true" patch:"true"`
+	Status      CreateStatus `json:"status" get:"true" post:"true" patch:"true"`
+	Description string       `json:"description" get:"true" post:"true" patch:"true"`
+	CreatedAt   time.Time    `json:"created_at" get:"true"`
 }

--- a/amodel/snapshotrestorelog.go
+++ b/amodel/snapshotrestorelog.go
@@ -11,9 +11,10 @@ const (
 )
 
 type SnapshotRestoreLog struct {
-	UUID      string        `json:"uuid" gorm:"primary_key" get:"true" delete:"true"`
-	HostUUID  string        `json:"host_uuid" get:"true" post:"true" patch:"true"`
-	Msg       string        `json:"msg" get:"true" post:"true" patch:"true"`
-	Status    RestoreStatus `json:"status" get:"true" post:"true" patch:"true"`
-	CreatedAt time.Time     `json:"created_at" get:"true"`
+	UUID        string        `json:"uuid" gorm:"primary_key" get:"true" delete:"true"`
+	HostUUID    string        `json:"host_uuid" get:"true" post:"true" patch:"true"`
+	Msg         string        `json:"msg" get:"true" post:"true" patch:"true"`
+	Status      RestoreStatus `json:"status" get:"true" post:"true" patch:"true"`
+	Description string        `json:"description" get:"true" post:"true" patch:"true"`
+	CreatedAt   time.Time     `json:"created_at" get:"true"`
 }

--- a/controller/snapshotcreatelog.go
+++ b/controller/snapshotcreatelog.go
@@ -1,6 +1,14 @@
 package controller
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/NubeIO/rubix-assist/amodel"
+	"github.com/gin-gonic/gin"
+)
+
+func getSnapshotCreateLogBody(ctx *gin.Context) (dto *amodel.SnapshotCreateLog, err error) {
+	err = ctx.ShouldBindJSON(&dto)
+	return dto, err
+}
 
 func (inst *Controller) GetSnapshotCreateLogs(c *gin.Context) {
 	host, err := inst.resolveHost(c)
@@ -15,4 +23,14 @@ func (inst *Controller) GetSnapshotCreateLogs(c *gin.Context) {
 func (inst *Controller) DeleteSnapshotCreateLog(c *gin.Context) {
 	q, err := inst.DB.DeleteSnapshotCreateLog(c.Params.ByName("uuid"))
 	responseHandler(q, err, c)
+}
+
+func (inst *Controller) UpdateSnapshotCreateLog(c *gin.Context) {
+	body, _ := getSnapshotCreateLogBody(c)
+	createLog, err := inst.DB.UpdateSnapshotCreateLog(c.Params.ByName("uuid"), body)
+	if err != nil {
+		responseHandler(nil, err, c)
+		return
+	}
+	responseHandler(createLog, err, c)
 }

--- a/controller/snapshotrestorelog.go
+++ b/controller/snapshotrestorelog.go
@@ -1,6 +1,14 @@
 package controller
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/NubeIO/rubix-assist/amodel"
+	"github.com/gin-gonic/gin"
+)
+
+func getSnapshotRestoreLogBody(ctx *gin.Context) (dto *amodel.SnapshotRestoreLog, err error) {
+	err = ctx.ShouldBindJSON(&dto)
+	return dto, err
+}
 
 func (inst *Controller) GetSnapshotRestoreLogs(c *gin.Context) {
 	host, err := inst.resolveHost(c)
@@ -15,4 +23,14 @@ func (inst *Controller) GetSnapshotRestoreLogs(c *gin.Context) {
 func (inst *Controller) DeleteSnapshotRestoreLog(c *gin.Context) {
 	q, err := inst.DB.DeleteSnapshotRestoreLog(c.Params.ByName("uuid"))
 	responseHandler(q, err, c)
+}
+
+func (inst *Controller) UpdateSnapshotRestoreLog(c *gin.Context) {
+	body, _ := getSnapshotRestoreLogBody(c)
+	restoreLog, err := inst.DB.UpdateSnapshotRestoreLog(c.Params.ByName("uuid"), body)
+	if err != nil {
+		responseHandler(nil, err, c)
+		return
+	}
+	responseHandler(restoreLog, err, c)
 }

--- a/pkg/interfaces/edgesnapshot.go
+++ b/pkg/interfaces/edgesnapshot.go
@@ -1,0 +1,10 @@
+package interfaces
+
+type CreateSnapshot struct {
+	Description string `json:"description"`
+}
+
+type RestoreSnapshot struct {
+	File        string `json:"file"`
+	Description string `json:"description"`
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -245,8 +245,10 @@ func Setup(db *gorm.DB) *gin.Engine {
 		edgeSnapshots.POST("/create", api.CreateSnapshot)
 		edgeSnapshots.POST("/restore", api.RestoreSnapshot)
 		edgeSnapshots.GET("/create-logs", api.GetSnapshotCreateLogs)
+		edgeSnapshots.PATCH("/create-logs/:uuid", api.UpdateSnapshotCreateLog)
 		edgeSnapshots.DELETE("/create-logs/:uuid", api.DeleteSnapshotCreateLog)
 		edgeSnapshots.GET("/restore-logs", api.GetSnapshotRestoreLogs)
+		edgeSnapshots.PATCH("/restore-logs/:uuid", api.UpdateSnapshotRestoreLog)
 		edgeSnapshots.DELETE("/restore-logs/:uuid", api.DeleteSnapshotRestoreLog)
 	}
 


### PR DESCRIPTION
Resolves: #96 
### Summary:
- Added description field on create and restore logs.
- Added PATCH api endpoint for create and restore logs. Examples:
```
   - PATCH `api/edge/snapshots/create-logs/<uuid>`
        -d {
            description:<description>
        }
   - PATCH `api/edge/snapshots/restore-logs/<uuid>`
       -d {
            description:<description>
        }
```
- Modified `api/edge/snapshots/create` and `api/edge/snapshots/restore`. Examples:
```
   - POST `api/edge/snapshots/create`
        -d {
            description:<description>
        }
   - POST `api/edge/snapshots/restore`
       -d {
            file:<file>,
            description:<description>
        }
