### PR TITLE
Add tags and comments for host

### DIFF
--- a/amodel/host.go
+++ b/amodel/host.go
@@ -2,32 +2,47 @@ package amodel
 
 import (
 	"github.com/NubeIO/lib-schema/schema"
+	"time"
 )
 
 type Host struct {
-	UUID           string `json:"uuid" gorm:"primaryKey"`
-	GlobalUUID     string `json:"global_uuid"`
-	Name           string `json:"name"  gorm:"type:varchar(255);not null;uniqueIndex:idx_hosts_name_network_uuid"`
-	NetworkUUID    string `json:"network_uuid,omitempty" gorm:"TYPE:varchar(255) REFERENCES networks;not null;default:null;uniqueIndex:idx_hosts_name_network_uuid"`
-	Enable         *bool  `json:"enable"`
-	Description    string `json:"description"`
-	IP             string `json:"ip"`
-	BiosPort       int    `json:"bios_port"`
-	Port           int    `json:"port"`
-	HTTPS          *bool  `json:"https"`
-	IsOnline       *bool  `json:"is_online"`
-	IsValidToken   *bool  `json:"is_valid_token"`
-	ExternalToken  string `json:"external_token"`
-	VirtualIP      string `json:"virtual_ip"`
-	ReceivedBytes  int    `json:"received_bytes"`
-	SentBytes      int    `json:"sent_bytes"`
-	ConnectedSince string `json:"connected_since"`
+	UUID           string         `json:"uuid" gorm:"primaryKey"`
+	GlobalUUID     string         `json:"global_uuid"`
+	Name           string         `json:"name"  gorm:"type:varchar(255);not null;uniqueIndex:idx_hosts_name_network_uuid"`
+	NetworkUUID    string         `json:"network_uuid,omitempty" gorm:"TYPE:varchar(255) REFERENCES networks;not null;default:null;uniqueIndex:idx_hosts_name_network_uuid"`
+	Enable         *bool          `json:"enable"`
+	Description    string         `json:"description"`
+	IP             string         `json:"ip"`
+	BiosPort       int            `json:"bios_port"`
+	Port           int            `json:"port"`
+	HTTPS          *bool          `json:"https"`
+	IsOnline       *bool          `json:"is_online"`
+	IsValidToken   *bool          `json:"is_valid_token"`
+	ExternalToken  string         `json:"external_token"`
+	VirtualIP      string         `json:"virtual_ip"`
+	ReceivedBytes  int            `json:"received_bytes"`
+	SentBytes      int            `json:"sent_bytes"`
+	ConnectedSince string         `json:"connected_since"`
+	Tags           []*HostTag     `json:"tags,omitempty" gorm:"constraint:OnDelete:CASCADE"`
+	Comments       []*HostComment `json:"comments,omitempty" gorm:"constraint:OnDelete:CASCADE"`
 }
 
 type NetworkUUID struct {
 	Type     string `json:"type" default:"string"`
 	Title    string `json:"title" default:"uuid"`
 	ReadOnly bool   `json:"readOnly" default:"true"`
+}
+
+type HostTag struct {
+	HostUUID string `json:"host_uuid,omitempty" gorm:"type:varchar(255) references hosts;not null;default:null;primaryKey"`
+	Tag      string `json:"tag" gorm:"primaryKey"`
+}
+
+type HostComment struct {
+	UUID      string    `json:"uuid" gorm:"primaryKey"`
+	HostUUID  string    `json:"host_uuid,omitempty" gorm:"type:varchar(255) references hosts;not null;"`
+	Comment   string    `json:"comment"`
+	UpdatedAt time.Time `json:"date,omitempty"`
 }
 
 type SSHUsername struct {

--- a/controller/hostcomment.go
+++ b/controller/hostcomment.go
@@ -1,0 +1,37 @@
+package controller
+
+import (
+	"github.com/NubeIO/rubix-assist/amodel"
+	"github.com/gin-gonic/gin"
+)
+
+func getHostCommentBody(ctx *gin.Context) (dto *amodel.HostComment, err error) {
+	err = ctx.ShouldBindJSON(&dto)
+	return dto, err
+}
+
+func (inst *Controller) CreateHostComment(c *gin.Context) {
+	m := new(amodel.HostComment)
+	err := c.ShouldBindJSON(&m)
+	host, err := inst.DB.CreateHostComment(m)
+	if err != nil {
+		responseHandler(nil, err, c)
+		return
+	}
+	responseHandler(host, err, c)
+}
+
+func (inst *Controller) UpdateHostComment(c *gin.Context) {
+	body, _ := getHostCommentBody(c)
+	host, err := inst.DB.UpdateHostComment(c.Params.ByName("uuid"), body)
+	if err != nil {
+		responseHandler(nil, err, c)
+		return
+	}
+	responseHandler(host, err, c)
+}
+
+func (inst *Controller) DeleteHostComment(c *gin.Context) {
+	q, err := inst.DB.DeleteHostComment(c.Params.ByName("uuid"))
+	responseHandler(q, err, c)
+}

--- a/controller/hosttag.go
+++ b/controller/hosttag.go
@@ -1,0 +1,21 @@
+package controller
+
+import (
+	"github.com/NubeIO/rubix-assist/amodel"
+	"github.com/gin-gonic/gin"
+)
+
+func getHostTagsBody(ctx *gin.Context) (dto []*amodel.HostTag, err error) {
+	err = ctx.ShouldBindJSON(&dto)
+	return dto, err
+}
+
+func (inst *Controller) UpdateHostTags(c *gin.Context) {
+	body, _ := getHostTagsBody(c)
+	host, err := inst.DB.UpdateHostTags(c.Params.ByName("host_uuid"), body)
+	if err != nil {
+		responseHandler(nil, err, c)
+		return
+	}
+	responseHandler(host, err, c)
+}

--- a/database/host.go
+++ b/database/host.go
@@ -7,13 +7,18 @@ import (
 	"github.com/NubeIO/nubeio-rubix-lib-helpers-go/pkg/nils"
 	"github.com/NubeIO/rubix-assist/amodel"
 	"github.com/NubeIO/rubix-assist/cligetter"
+	"gorm.io/gorm"
 )
 
 const hostName = "host"
 
+func (inst *DB) buildHostQuery() *gorm.DB {
+	return inst.DB.Preload("Comments").Preload("Tags")
+}
+
 func (inst *DB) GetHost(uuid string) (*amodel.Host, error) {
 	host := amodel.Host{}
-	if err := inst.DB.Where("uuid = ? ", uuid).First(&host).Error; err != nil {
+	if err := inst.buildHostQuery().Where("uuid = ? ", uuid).First(&host).Error; err != nil {
 		return nil, errors.New(fmt.Sprintf("no host was found with uuid: %s", uuid))
 	}
 	return &host, nil
@@ -21,7 +26,7 @@ func (inst *DB) GetHost(uuid string) (*amodel.Host, error) {
 
 func (inst *DB) GetHostByName(name string) (*amodel.Host, error) {
 	host := amodel.Host{}
-	if err := inst.DB.Where("name = ? ", name).First(&host).Error; err != nil {
+	if err := inst.buildHostQuery().Where("name = ? ", name).First(&host).Error; err != nil {
 		return nil, errors.New(fmt.Sprintf("no host was found with name: %s", name))
 	}
 	return &host, nil
@@ -29,7 +34,7 @@ func (inst *DB) GetHostByName(name string) (*amodel.Host, error) {
 
 func (inst *DB) GetHosts(withOpenVPN bool) ([]*amodel.Host, error) {
 	var hosts []*amodel.Host
-	if err := inst.DB.Find(&hosts).Error; err != nil {
+	if err := inst.buildHostQuery().Find(&hosts).Error; err != nil {
 		return nil, err
 	}
 	if withOpenVPN {

--- a/database/hostcomment.go
+++ b/database/hostcomment.go
@@ -1,0 +1,29 @@
+package base
+
+import (
+	"github.com/NubeIO/lib-uuid/uuid"
+	"github.com/NubeIO/rubix-assist/amodel"
+)
+
+func (inst *DB) CreateHostComment(body *amodel.HostComment) (*amodel.HostComment, error) {
+	body.UUID = uuid.ShortUUID("hcm")
+	if err := inst.DB.Create(&body).Error; err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func (inst *DB) UpdateHostComment(uuid string, body *amodel.HostComment) (*amodel.HostComment, error) {
+	m := new(amodel.HostComment)
+	err := inst.DB.Where("uuid = ?", uuid).Find(&m).Updates(body).Error
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (inst *DB) DeleteHostComment(uuid string) (*DeleteMessage, error) {
+	var m *amodel.HostComment
+	query := inst.DB.Where("uuid = ? ", uuid).Delete(&m)
+	return deleteResponse(query)
+}

--- a/database/hosttag.go
+++ b/database/hosttag.go
@@ -1,0 +1,34 @@
+package base
+
+import (
+	"github.com/NubeIO/rubix-assist/amodel"
+	"gorm.io/gorm/clause"
+	"strings"
+)
+
+func (inst *DB) UpdateHostTags(hostUUID string, body []*amodel.HostTag) ([]*amodel.HostTag, error) {
+	tx := inst.DB.Begin()
+	var tags []string
+	for i, b := range body {
+		body[i].HostUUID = hostUUID
+		tags = append(tags, b.Tag)
+	}
+	notIn := strings.Join(tags, ",")
+	if err := tx.Where("host_uuid = ?", hostUUID).Where("tag not in (?)", notIn).Delete(&amodel.HostTag{}).
+		Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	if len(body) > 0 {
+		if err := tx.Clauses(clause.OnConflict{UpdateAll: true}).Create(body).Error; err != nil {
+			tx.Rollback()
+			return nil, err
+		}
+	}
+	if err := tx.Where("host_uuid = ?", hostUUID).Find(&body).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	tx.Commit()
+	return body, nil
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -63,7 +63,9 @@ func Setup() error {
 		&amodel.Transaction{},
 		&amodel.SnapshotLog{},
 		&amodel.SnapshotCreateLog{},
-		&amodel.SnapshotRestoreLog{})
+		&amodel.SnapshotRestoreLog{},
+		&amodel.HostTag{},
+		&amodel.HostComment{})
 	if err != nil {
 		return err
 	}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -140,6 +140,17 @@ func Setup(db *gorm.DB) *gin.Engine {
 		hosts.DELETE("/:uuid", api.DeleteHost)
 		hosts.DELETE("/drop", api.DropHosts)
 		hosts.GET("/:uuid/configure-openvpn", api.ConfigureOpenVPN)
+
+		hostTags := hosts.Group("/tags")
+		{
+			hostTags.PUT("/host_uuid/:host_uuid", api.UpdateHostTags)
+		}
+		hostComments := hosts.Group("/comments")
+		{
+			hostComments.POST("", api.CreateHostComment)
+			hostComments.PATCH("/:uuid", api.UpdateHostComment)
+			hostComments.DELETE("/:uuid", api.DeleteHostComment)
+		}
 	}
 
 	teams := apiRoutes.Group("/teams")


### PR DESCRIPTION
Resolves: #98 
### Summary:
- Modified api endpoint `/api/hosts`. Example
   - POST `/api/hosts` 
     ```
     -d {
          "tags": [{"tag": "<tag>"}, {"tag": "<tag>"}]
       }
     ```
- Added api endpoint `api/hosts/tags/host_uuid/<host_uuid>`. Example:
    - PUT `/api/hosts/tags/host_uuid/<host_uuid>` 
     ```
     -d [{"tag": "<tag>"}, {"tag": "<tag>"}]
     ```
- Added api endpoint `api/hosts/comments`. Examples:
    - POST `/api/hosts/comments` 
     ```
     -d {
          "host_uuid":"hos_c12645a8207f",
          "comment":"<comment>"
      }
     ```
    - PATCH `/api/hosts/comments/<uuid>` 
     ```
     -d {
          "comment":"<comment>"
      }
     ```
    - DELETE `/api/hosts/comments/<uuid>` 