### PR TITLE
Add api endpoints to download and upload snapshot

### DIFF
--- a/controller/edgesnapshot.go
+++ b/controller/edgesnapshot.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -174,6 +175,46 @@ func (inst *Controller) RestoreSnapshot(c *gin.Context) {
 		_, _ = inst.DB.UpdateSnapshotRestoreLog(restoreLog.UUID, restoreLog)
 	}()
 	responseHandler(amodel.Message{Message: "restore snapshot process has submitted"}, nil, c)
+}
+
+func (inst *Controller) DownloadSnapshot(c *gin.Context) {
+	file := c.Query("file")
+	c.FileAttachment(path.Join(config.Config.GetAbsSnapShotDir(), file), file)
+}
+
+func (inst *Controller) UploadSnapshot(c *gin.Context) {
+	file, err := c.FormFile("file")
+	if err != nil || file == nil {
+		responseHandler(nil, err, c)
+		return
+	}
+	description := c.Query("description")
+
+	toFileLocation := path.Join(config.Config.GetAbsSnapShotDir(), filepath.Base(file.Filename))
+	if err := c.SaveUploadedFile(file, toFileLocation); err != nil {
+		responseHandler(nil, err, c)
+		return
+	}
+
+	snapshotLog := amodel.SnapshotLog{
+		File:        file.Filename,
+		Description: description,
+	}
+	_, err = inst.DB.UpdateSnapshotLog(file.Filename, &snapshotLog)
+	if err != nil {
+		log.Error(err)
+	}
+	files, err := inst.getSnapshotsFiles()
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	_, err = inst.DB.DeleteSnapshotLogs(files)
+	if err != nil {
+		log.Error(err)
+	}
+
+	responseHandler(amodel.Message{Message: "snapshot uploaded successfully"}, nil, c)
 }
 
 func (inst *Controller) getSnapshots(arch string) ([]Snapshots, error) {

--- a/controller/edgesnapshot.go
+++ b/controller/edgesnapshot.go
@@ -189,8 +189,12 @@ func (inst *Controller) UploadSnapshot(c *gin.Context) {
 		return
 	}
 	description := c.Query("description")
-
-	toFileLocation := path.Join(config.Config.GetAbsSnapShotDir(), filepath.Base(file.Filename))
+	fileName := strings.ReplaceAll(file.Filename, " ", "")
+	if path.Ext(fileName) != ".zip" {
+		responseHandler(nil, errors.New("file is not a valid zip file"), c)
+		return
+	}
+	toFileLocation := path.Join(config.Config.GetAbsSnapShotDir(), filepath.Base(fileName))
 	if err := c.SaveUploadedFile(file, toFileLocation); err != nil {
 		responseHandler(nil, err, c)
 		return

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -269,6 +269,8 @@ func Setup(db *gorm.DB) *gin.Engine {
 		edgeSnapshots.DELETE("", api.DeleteSnapshot)
 		edgeSnapshots.POST("/create", api.CreateSnapshot)
 		edgeSnapshots.POST("/restore", api.RestoreSnapshot)
+		edgeSnapshots.POST("/download", api.DownloadSnapshot)
+		edgeSnapshots.POST("/upload", api.UploadSnapshot)
 		edgeSnapshots.GET("/create-logs", api.GetSnapshotCreateLogs)
 		edgeSnapshots.PATCH("/create-logs/:uuid", api.UpdateSnapshotCreateLog)
 		edgeSnapshots.DELETE("/create-logs/:uuid", api.DeleteSnapshotCreateLog)


### PR DESCRIPTION
Resolves: #112 
### Summary:
- Added POST `api/edge/snapshots/download?file=<file_name>`
  ```
  curl -X POST http://localhost:1661/api/edge/snapshots/download?file=20230420T092409_amd64.zip
  ```
- Added POST `api/edge/snapshots/upload?description=<description> -F "file=@<file_path>"`. Example
  ```
  curl -X POST http://localhost:1661/api/edge/snapshots/upload?description=<description> -F "file=@/home/user/Downloads/20230420T092409_amd64.zip" -H "Content-Type: multipart/form-data
  ```